### PR TITLE
HW Only mode support

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -799,6 +799,9 @@
   "hwOnlyStarted": {
     "message": "Get Started as HW Only"
   },
+  "hwOnlyModeSwitch": {
+    "message": "HW Only Mode"
+  },
   "goerli": {
     "message": "Goerli Test Network"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -796,6 +796,9 @@
   "getStarted": {
     "message": "Get Started"
   },
+  "hwOnlyStarted": {
+    "message": "Get Started as HW Only"
+  },
   "goerli": {
     "message": "Goerli Test Network"
   },

--- a/app/_locales/zh/messages.json
+++ b/app/_locales/zh/messages.json
@@ -793,6 +793,9 @@
   "getStarted": {
     "message": "开始使用"
   },
+  "hwOnlyStarted": {
+    "message": "仅连接硬件使用"
+  },
   "goerli": {
     "message": "Goerli 测试网络"
   },

--- a/app/_locales/zh/messages.json
+++ b/app/_locales/zh/messages.json
@@ -796,6 +796,9 @@
   "hwOnlyStarted": {
     "message": "仅连接硬件使用"
   },
+  "hwOnlyModeSwitch": {
+    "message": "仅连接硬件模式"
+  },
   "goerli": {
     "message": "Goerli 测试网络"
   },

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -63,6 +63,20 @@ const localStore = inTest ? new ReadOnlyNetworkStore() : new LocalStore();
 let versionedData;
 
 if (inTest || process.env.METAMASK_DEBUG) {
+  // set global localStore for debug
+  global.onekeyLocalStore = localStore;
+  global.onekeyLocalStore.clear = async (callback) => {
+    await localStore.set({ data: {}, meta: {} });
+    console.log(JSON.stringify(await localStore.get(), null, 4));
+    console.log('Page will be reloaded in 3s...');
+    setTimeout(() => {
+      // eslint-disable-next-line node/callback-return
+      callback && callback();
+      setTimeout(() => {
+        window.location.reload();
+      }, 500);
+    }, 2000);
+  };
   global.metamaskGetState = localStore.get.bind(localStore);
 }
 

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -18,6 +18,8 @@ import {
   NETWORK_TYPE_TO_ID_MAP,
   MAINNET_CHAIN_ID,
   RINKEBY_CHAIN_ID,
+  ROPSTEN_CHAIN_ID,
+  ROPSTEN,
 } from '../../../../shared/constants/network';
 import {
   isPrefixedFormattedHexString,
@@ -38,7 +40,7 @@ if (process.env.IN_TEST === 'true') {
     nickname: 'Localhost 8545',
   };
 } else if (process.env.METAMASK_DEBUG || env === 'test') {
-  defaultProviderConfigOpts = { type: RINKEBY, chainId: RINKEBY_CHAIN_ID };
+  defaultProviderConfigOpts = { type: ROPSTEN, chainId: ROPSTEN_CHAIN_ID };
 } else {
   defaultProviderConfigOpts = { type: MAINNET, chainId: MAINNET_CHAIN_ID };
 }
@@ -173,7 +175,7 @@ export default class NetworkController extends EventEmitter {
 
   getNativeCurrency() {
     const { type, ticker } = this.getProviderConfig();
-    const nativeCurrency = ticker ? ticker : (NETWORK_TYPE_TO_ID_MAP[type] || "ETH")
+    const nativeCurrency = ticker || NETWORK_TYPE_TO_ID_MAP[type] || 'ETH';
     return nativeCurrency;
   }
 
@@ -197,7 +199,7 @@ export default class NetworkController extends EventEmitter {
   }
 
   async setProviderType(type) {
-    const { rpcUrl, chainId, ticker = "ETH" } = NETWORK_TYPE_TO_ID_MAP[type];
+    const { rpcUrl, chainId, ticker = 'ETH' } = NETWORK_TYPE_TO_ID_MAP[type];
     assert.notStrictEqual(
       type,
       NETWORK_TYPE_RPC,
@@ -207,7 +209,7 @@ export default class NetworkController extends EventEmitter {
       [].concat(INFURA_PROVIDER_TYPES, BUILDINT_PROVIDER_TYPES).includes(type),
       `Unknown Infura provider type "${type}".`,
     );
-    this.setProviderConfig({ type, rpcUrl, chainId, ticker, nickname: "" });
+    this.setProviderConfig({ type, rpcUrl, chainId, ticker, nickname: '' });
   }
 
   resetConnection() {

--- a/app/scripts/controllers/preferences.js
+++ b/app/scripts/controllers/preferences.js
@@ -65,6 +65,7 @@ export default class PreferencesController {
         useNativeCurrencyAsPrimaryCurrency: true,
       },
       completedOnboarding: false,
+      hwOnlyMode: false,
       // ENS decentralized website resolution
       ipfsGateway: 'dweb.link',
       ...opts.initState,
@@ -657,6 +658,11 @@ export default class PreferencesController {
     return Promise.resolve(true);
   }
 
+  setHwOnlyMode(status = true) {
+    this.store.updateState({ hwOnlyMode: status });
+    return Promise.resolve(true);
+  }
+
   /**
    * A getter for the `ipfsGateway` property
    * @returns {string} The current IPFS gateway domain
@@ -686,7 +692,11 @@ export default class PreferencesController {
    */
   _subscribeProviderType() {
     this.network.providerStore.subscribe(() => {
-      const { tokens, hiddenTokens, tokensWithBalance = [] } = this._getTokenRelatedStates();
+      const {
+        tokens,
+        hiddenTokens,
+        tokensWithBalance = [],
+      } = this._getTokenRelatedStates();
       this._updateAccountTokens(tokens, this.getAssetImages(), hiddenTokens);
       this.updateTokensWithBalance(tokensWithBalance);
     });
@@ -749,7 +759,11 @@ export default class PreferencesController {
    *
    */
   _getTokenRelatedStates(selectedAddress) {
-    const { accountTokens, accountHiddenTokens, accountTokensWithBalance } = this.store.getState();
+    const {
+      accountTokens,
+      accountHiddenTokens,
+      accountTokensWithBalance,
+    } = this.store.getState();
     if (!selectedAddress) {
       // eslint-disable-next-line no-param-reassign
       selectedAddress = this.store.getState().selectedAddress;
@@ -775,7 +789,8 @@ export default class PreferencesController {
     }
     const tokens = accountTokens[selectedAddress][providerType];
     const hiddenTokens = accountHiddenTokens[selectedAddress][providerType];
-    const tokensWithBalance = accountTokensWithBalance[selectedAddress][providerType];
+    const tokensWithBalance =
+      accountTokensWithBalance[selectedAddress][providerType];
     return {
       tokens,
       accountTokens,

--- a/development/build/scripts.js
+++ b/development/build/scripts.js
@@ -60,13 +60,16 @@ const metamaskDepenendencies = [
   '@metamask/jazzicon',
   '@metamask/logo',
   '@metamask/obs-store',
-
 ];
 const reactDepenendencies = dependencies.filter((dep) => dep.match(/react/u));
 
 const externalDependenciesMap = {
   background: ['3box'],
-  ui: [...materialUIDependencies, ...reactDepenendencies, ...metamaskDepenendencies],
+  ui: [
+    ...materialUIDependencies,
+    ...reactDepenendencies,
+    ...metamaskDepenendencies,
+  ],
 };
 
 function createScriptTasks({ browserPlatforms, livereload }) {
@@ -353,6 +356,7 @@ function createScriptTasks({ browserPlatforms, livereload }) {
         CONF: opts.devMode ? conf : {},
         SENTRY_DSN: process.env.SENTRY_DSN || conf.SENTRY_DSN,
         SENTRY_DSN_DEV: process.env.SENTRY_DSN_DEV || conf.SENTRY_DSN_DEV,
+        ENV_ON_BOARDING_START_CHOICE: process.env.ENV_ON_BOARDING_START_CHOICE,
         INFURA_PROJECT_ID: opts.testing
           ? '00000000000000000000000000000000'
           : conf.INFURA_PROJECT_ID,

--- a/ui/app/components/app/account-menu/account-menu.container.js
+++ b/ui/app/components/app/account-menu/account-menu.container.js
@@ -24,13 +24,14 @@ const SHOW_SEARCH_ACCOUNTS_MIN_COUNT = 5;
 
 function mapStateToProps(state) {
   const {
-    metamask: { isAccountMenuOpen },
+    metamask: { isAccountMenuOpen, hwOnlyMode },
   } = state;
   const accounts = getMetaMaskAccountsOrdered(state);
   const origin = getOriginOfCurrentTab(state);
   const selectedAddress = getSelectedAddress(state);
 
   return {
+    hwOnlyMode,
     isAccountMenuOpen,
     addressConnectedDomainMap: getAddressConnectedDomainMap(state),
     originOfCurrentTab: origin,

--- a/ui/app/components/app/permission-page-container/index.scss
+++ b/ui/app/components/app/permission-page-container/index.scss
@@ -110,7 +110,8 @@
       justify-content: space-between;
 
       button {
-        width: 124px;
+        flex: 1;
+
       }
     }
   }

--- a/ui/app/ducks/metamask/metamask.js
+++ b/ui/app/ducks/metamask/metamask.js
@@ -44,6 +44,7 @@ export default function reduceMetamask(state = {}, action) {
     },
     firstTimeFlowType: null,
     completedOnboarding: false,
+    hwOnlyMode: false,
     knownMethodData: {},
     participateInMetaMetrics: null,
     metaMetricsSendCount: 0,
@@ -305,7 +306,7 @@ export default function reduceMetamask(state = {}, action) {
         ...metamaskState,
         useBlockie: action.value,
       };
-    
+
     case actionConstants.SET_USE_AUTO_SWITCH_CHAIN:
       return {
         ...metamaskState,
@@ -357,6 +358,13 @@ export default function reduceMetamask(state = {}, action) {
       return {
         ...metamaskState,
         completedOnboarding: true,
+      };
+    }
+
+    case actionConstants.SET_HW_ONLY_MODE: {
+      return {
+        ...metamaskState,
+        hwOnlyMode: action.value,
       };
     }
 

--- a/ui/app/helpers/constants/common.js
+++ b/ui/app/helpers/constants/common.js
@@ -14,6 +14,8 @@ export const GAS_ESTIMATE_TYPES = {
   FASTEST: 'FASTEST',
 };
 
+export const CONST_DEFAULT_PASSWORD_IN_TEST = '88888888';
+
 export const CONST_FIRST_TIME_FLOW_TYPES = {
   CREATE: 'create',
   IMPORT: 'import',

--- a/ui/app/helpers/constants/common.js
+++ b/ui/app/helpers/constants/common.js
@@ -13,3 +13,16 @@ export const GAS_ESTIMATE_TYPES = {
   FAST: 'FAST',
   FASTEST: 'FASTEST',
 };
+
+export const CONST_FIRST_TIME_FLOW_TYPES = {
+  CREATE: 'create',
+  IMPORT: 'import',
+  CONNECT_HW: 'connect-hw',
+};
+
+export const CONST_ACCOUNT_TYPES = {
+  HARDWARE: 'hardware', // Trezor Hardware, Ledger Hardware
+  IMPORTED: 'imported', // Simple Key Pair
+  WATCHED: 'watched', // Watch Account
+  DEFAULT: 'default',
+};

--- a/ui/app/helpers/utils/util.js
+++ b/ui/app/helpers/utils/util.js
@@ -521,7 +521,6 @@ export function getAccountMetaInfo({ account, keyrings }) {
   const keyring = getAccountKeyring({ account, keyrings });
   const accountType = keyringTypeToAccountType(keyring && keyring.type);
   return {
-    keyring, // TODO remove
     accountKeyring: keyring,
     accountType,
   };

--- a/ui/app/pages/create-account/create-account.component.js
+++ b/ui/app/pages/create-account/create-account.component.js
@@ -14,6 +14,7 @@ import ConnectHardwareForm from './connect-hardware';
 export default class CreateAccountPage extends Component {
   renderTabs() {
     const {
+      hwOnlyMode,
       history,
       location: { pathname },
     } = this.props;
@@ -27,18 +28,23 @@ export default class CreateAccountPage extends Component {
 
     return (
       <div className="new-account__tabs">
-        <div
-          className={getClassNames(NEW_ACCOUNT_ROUTE)}
-          onClick={() => history.push(NEW_ACCOUNT_ROUTE)}
-        >
-          {this.context.t('create')}
-        </div>
-        <div
-          className={getClassNames(IMPORT_ACCOUNT_ROUTE)}
-          onClick={() => history.push(IMPORT_ACCOUNT_ROUTE)}
-        >
-          {this.context.t('import')}
-        </div>
+        {!hwOnlyMode && (
+          <>
+            <div
+              className={getClassNames(NEW_ACCOUNT_ROUTE)}
+              onClick={() => history.push(NEW_ACCOUNT_ROUTE)}
+            >
+              {this.context.t('create')}
+            </div>
+            <div
+              className={getClassNames(IMPORT_ACCOUNT_ROUTE)}
+              onClick={() => history.push(IMPORT_ACCOUNT_ROUTE)}
+            >
+              {this.context.t('import')}
+            </div>
+          </>
+        )}
+
         <div
           className={getClassNames(CONNECT_HARDWARE_ROUTE)}
           onClick={() => history.push(CONNECT_HARDWARE_ROUTE)}
@@ -86,6 +92,7 @@ export default class CreateAccountPage extends Component {
 CreateAccountPage.propTypes = {
   location: PropTypes.object,
   history: PropTypes.object,
+  hwOnlyMode: PropTypes.bool,
 };
 
 CreateAccountPage.contextTypes = {

--- a/ui/app/pages/create-account/index.js
+++ b/ui/app/pages/create-account/index.js
@@ -9,5 +9,3 @@ const mapStateToProps = (state) => {
 };
 
 export default connect(mapStateToProps)(CreateAccountPage);
-
-// export { default } from './create-account.component';

--- a/ui/app/pages/create-account/index.js
+++ b/ui/app/pages/create-account/index.js
@@ -1,1 +1,13 @@
-export { default } from './create-account.component';
+import { connect } from 'react-redux';
+import CreateAccountPage from './create-account.component';
+
+const mapStateToProps = (state) => {
+  const { hwOnlyMode } = state.metamask;
+  return {
+    hwOnlyMode,
+  };
+};
+
+export default connect(mapStateToProps)(CreateAccountPage);
+
+// export { default } from './create-account.component';

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -228,7 +228,6 @@ export default class ImportWithSeedPhrase extends PureComponent {
                   errorMessage: seedPhraseError,
                 },
               });
-              // TODO HW Only模式时，是返回到welcome页面
               // this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
               this.props.history.replace(INITIALIZE_WELCOME_ROUTE);
             }}

--- a/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/create-password/import-with-seed-phrase/import-with-seed-phrase.component.js
@@ -6,6 +6,7 @@ import Button from '../../../../components/ui/button';
 import {
   INITIALIZE_SELECT_ACTION_ROUTE,
   INITIALIZE_END_OF_FLOW_ROUTE,
+  INITIALIZE_WELCOME_ROUTE,
 } from '../../../../helpers/constants/routes';
 
 const { isValidMnemonic } = ethers.utils;
@@ -227,11 +228,14 @@ export default class ImportWithSeedPhrase extends PureComponent {
                   errorMessage: seedPhraseError,
                 },
               });
-              this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
+              // TODO HW Only模式时，是返回到welcome页面
+              // this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
+              this.props.history.replace(INITIALIZE_WELCOME_ROUTE);
             }}
             href="#"
           >
-            <span>&lt; </span><span>{t('back')}</span>
+            <span>&lt; </span>
+            <span>{t('back')}</span>
           </a>
         </div>
         <div className="first-time-flow__header">
@@ -257,9 +261,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
             />
           )}
           {seedPhraseError && <span className="error">{seedPhraseError}</span>}
-          <div
-            className="first-time-flow__checkbox-container"
-          >
+          <div className="first-time-flow__checkbox-container">
             <div
               className="first-time-flow__checkbox"
               tabIndex="0"
@@ -304,9 +306,7 @@ export default class ImportWithSeedPhrase extends PureComponent {
           margin="normal"
           largeLabel
         />
-        <div
-          className="first-time-flow__checkbox-container"
-        >
+        <div className="first-time-flow__checkbox-container">
           <div
             className="first-time-flow__checkbox first-time-flow__terms"
             tabIndex="0"

--- a/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -7,6 +7,8 @@ import {
   INITIALIZE_WELCOME_ROUTE,
 } from '../../../../helpers/constants/routes';
 import TextField from '../../../../components/ui/text-field';
+import { isInDebugTestEnv } from '../../../../helpers/utils/util';
+import { CONST_DEFAULT_PASSWORD_IN_TEST } from '../../../../helpers/constants/common';
 
 export default class NewAccount extends PureComponent {
   static contextTypes = {
@@ -20,11 +22,12 @@ export default class NewAccount extends PureComponent {
   };
 
   state = {
-    password: '',
-    confirmPassword: '',
+    password: isInDebugTestEnv() ? CONST_DEFAULT_PASSWORD_IN_TEST : '',
+    confirmPassword: isInDebugTestEnv() ? CONST_DEFAULT_PASSWORD_IN_TEST : '',
     passwordError: '',
     confirmPasswordError: '',
-    termsChecked: false,
+    termsChecked: true,
+
   };
 
   isValid() {

--- a/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 import Button from '../../../../components/ui/button';
 import {
   INITIALIZE_SEED_PHRASE_ROUTE,
-  INITIALIZE_SELECT_ACTION_ROUTE, INITIALIZE_WELCOME_ROUTE,
+  INITIALIZE_SELECT_ACTION_ROUTE,
+  INITIALIZE_WELCOME_ROUTE,
 } from '../../../../helpers/constants/routes';
 import TextField from '../../../../components/ui/text-field';
 
@@ -158,12 +159,13 @@ export default class NewAccount extends PureComponent {
                   name: 'Go Back from Onboarding Create',
                 },
               });
-              this.props.history.replace(INITIALIZE_WELCOME_ROUTE);
               // this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
+              this.props.history.replace(INITIALIZE_WELCOME_ROUTE);
             }}
             href="#"
           >
-            <span>&lt; </span><span>{t('back')}</span>
+            <span>&lt; </span>
+            <span>{t('back')}</span>
           </a>
         </div>
         <div className="first-time-flow__header">{t('createPassword')}</div>
@@ -197,9 +199,7 @@ export default class NewAccount extends PureComponent {
             fullWidth
             largeLabel
           />
-          <div
-            className="first-time-flow__checkbox-container"
-          >
+          <div className="first-time-flow__checkbox-container">
             <div
               className="first-time-flow__checkbox"
               tabIndex="0"

--- a/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
+++ b/ui/app/pages/first-time-flow/create-password/new-account/new-account.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Button from '../../../../components/ui/button';
 import {
   INITIALIZE_SEED_PHRASE_ROUTE,
-  INITIALIZE_SELECT_ACTION_ROUTE,
+  INITIALIZE_SELECT_ACTION_ROUTE, INITIALIZE_WELCOME_ROUTE,
 } from '../../../../helpers/constants/routes';
 import TextField from '../../../../components/ui/text-field';
 
@@ -108,6 +108,7 @@ export default class NewAccount extends PureComponent {
         },
       });
 
+      // show master wallet seed phrase
       history.push(INITIALIZE_SEED_PHRASE_ROUTE);
     } catch (error) {
       this.setState({ passwordError: error.message });
@@ -157,7 +158,8 @@ export default class NewAccount extends PureComponent {
                   name: 'Go Back from Onboarding Create',
                 },
               });
-              this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
+              this.props.history.replace(INITIALIZE_WELCOME_ROUTE);
+              // this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
             }}
             href="#"
           >

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/index.scss
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/index.scss
@@ -67,7 +67,7 @@
 
   &__buttons {
     display: flex;
-
+    margin-top: 16px;
     .first-time-flow__button:last-of-type {
       margin-left: 20px;
     }

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.component.js
@@ -8,8 +8,9 @@ import {
   INITIALIZE_CONFIRM_SEED_PHRASE_ROUTE,
   DEFAULT_ROUTE,
 } from '../../../../helpers/constants/routes';
-import { exportAsFile } from '../../../../helpers/utils/util';
+import { delayTimeout, exportAsFile } from '../../../../helpers/utils/util';
 import { returnToOnboardingInitiator } from '../../onboarding-initiator-util';
+import LoadingScreen from '../../../../components/ui/loading-screen';
 
 export default class RevealSeedPhrase extends PureComponent {
   static contextTypes = {
@@ -18,6 +19,7 @@ export default class RevealSeedPhrase extends PureComponent {
   };
 
   static propTypes = {
+    hwOnlyMode: PropTypes.bool,
     history: PropTypes.object,
     seedPhrase: PropTypes.string,
     setSeedPhraseBackedUp: PropTypes.func,
@@ -27,6 +29,14 @@ export default class RevealSeedPhrase extends PureComponent {
       tabId: PropTypes.number,
     }),
   };
+
+  componentDidMount() {
+    if (this.props.hwOnlyMode) {
+      delayTimeout(300).then(() => {
+        this.handleSkip();
+      });
+    }
+  }
 
   state = {
     isShowingSeedPhrase: false,
@@ -71,6 +81,7 @@ export default class RevealSeedPhrase extends PureComponent {
       },
     });
 
+    // setCompletedOnboarding
     await Promise.all([setCompletedOnboarding(), setSeedPhraseBackedUp(false)]);
 
     if (onboardingInitiator) {
@@ -123,7 +134,12 @@ export default class RevealSeedPhrase extends PureComponent {
   render() {
     const { t } = this.context;
     const { isShowingSeedPhrase } = this.state;
-    const { onboardingInitiator } = this.props;
+    const { onboardingInitiator, hwOnlyMode } = this.props;
+
+    // if hwOnlyMode, show loading
+    if (hwOnlyMode) {
+      return <LoadingScreen />;
+    }
 
     return (
       <div className="reveal-seed-phrase">

--- a/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.container.js
+++ b/ui/app/pages/first-time-flow/seed-phrase/reveal-seed-phrase/reveal-seed-phrase.container.js
@@ -7,7 +7,10 @@ import { getOnboardingInitiator } from '../../../../selectors';
 import RevealSeedPhrase from './reveal-seed-phrase.component';
 
 const mapStateToProps = (state) => {
+  const { hwOnlyMode } = state.metamask;
+
   return {
+    hwOnlyMode,
     onboardingInitiator: getOnboardingInitiator(state),
   };
 };

--- a/ui/app/pages/first-time-flow/select-action/select-action.component.js
+++ b/ui/app/pages/first-time-flow/select-action/select-action.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Button from '../../../components/ui/button';
 import MetaFoxLogo from '../../../components/ui/metafox-logo';
 import { INITIALIZE_METAMETRICS_OPT_IN_ROUTE } from '../../../helpers/constants/routes';
+import { CONST_FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/common';
 
 export default class SelectAction extends PureComponent {
   static propTypes = {
@@ -25,12 +26,12 @@ export default class SelectAction extends PureComponent {
   }
 
   handleCreate = () => {
-    this.props.setFirstTimeFlowType('create');
+    this.props.setFirstTimeFlowType(CONST_FIRST_TIME_FLOW_TYPES.CREATE);
     this.props.history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
   };
 
   handleImport = () => {
-    this.props.setFirstTimeFlowType('import');
+    this.props.setFirstTimeFlowType(CONST_FIRST_TIME_FLOW_TYPES.IMPORT);
     this.props.history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
   };
 
@@ -56,8 +57,10 @@ export default class SelectAction extends PureComponent {
                     {t('noAlreadyHaveSeed')}
                   </div>
                   <div className="select-action__button-text-small">
-                   <p>{t('importYourExisting')}</p>
-                   <p className="select-action__warning">{t('notUseHardware')}</p>
+                    <p>{t('importYourExisting')}</p>
+                    <p className="select-action__warning">
+                      {t('notUseHardware')}
+                    </p>
                   </div>
                 </div>
                 <Button

--- a/ui/app/pages/first-time-flow/welcome/index.scss
+++ b/ui/app/pages/first-time-flow/welcome/index.scss
@@ -35,13 +35,17 @@
     }
   }
 
+  &__buttons {
+    padding: 30px 0;
+  }
+
   .first-time-flow__button {
     width: 184px;
     font-weight: 500;
-    margin-top: 44px;
+    margin-top: 14px;
   }
 
-  .connect-hw-only__button {
-    margin-top: 14PX;
+  .first-time-flow__button + .connect-hw-only__button {
+    margin-top: 24PX;
   }
 }

--- a/ui/app/pages/first-time-flow/welcome/index.scss
+++ b/ui/app/pages/first-time-flow/welcome/index.scss
@@ -40,4 +40,8 @@
     font-weight: 500;
     margin-top: 44px;
   }
+
+  .connect-hw-only__button {
+    margin-top: 14PX;
+  }
 }

--- a/ui/app/pages/first-time-flow/welcome/welcome.component.js
+++ b/ui/app/pages/first-time-flow/welcome/welcome.component.js
@@ -5,14 +5,19 @@ import Mascot from '../../../components/ui/mascot';
 import Button from '../../../components/ui/button';
 import {
   INITIALIZE_CREATE_PASSWORD_ROUTE,
+  INITIALIZE_METAMETRICS_OPT_IN_ROUTE,
   INITIALIZE_SELECT_ACTION_ROUTE,
 } from '../../../helpers/constants/routes';
+import { CONST_FIRST_TIME_FLOW_TYPES } from '../../../helpers/constants/common';
 
 export default class Welcome extends PureComponent {
   static propTypes = {
     history: PropTypes.object,
     participateInMetaMetrics: PropTypes.bool,
     welcomeScreenSeen: PropTypes.bool,
+    hwOnlyMode: PropTypes.bool,
+    setFirstTimeFlowType: PropTypes.func,
+    setHwOnlyModeAsync: PropTypes.func,
   };
 
   static contextTypes = {
@@ -36,7 +41,14 @@ export default class Welcome extends PureComponent {
   }
 
   handleContinue = () => {
+    this.props.setHwOnlyModeAsync(false);
     this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
+  };
+
+  handleContinueHwOnly = () => {
+    this.props.setHwOnlyModeAsync(true);
+    this.props.setFirstTimeFlowType(CONST_FIRST_TIME_FLOW_TYPES.CONNECT_HW);
+    this.props.history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
   };
 
   render() {
@@ -45,9 +57,20 @@ export default class Welcome extends PureComponent {
     return (
       <div className="welcome-page__wrapper">
         <div className="welcome-page">
-          <svg width="120" height="120" viewBox="0 0 120 120" fill="none" xmlns="http://www.w3.org/2000/svg">
-            <circle cx="60" cy="60" r="60" fill="#00B812"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M60 59.026C69.4677 59.026 77.1429 66.4394 77.1429 75.5845C77.1429 84.7294 69.4677 92.1429 60 92.1429C50.5323 92.1429 42.8571 84.7294 42.8571 75.5845C42.8571 66.4394 50.5323 59.026 60 59.026ZM60.0001 66.543C54.8306 66.543 50.6399 70.5909 50.6399 75.5842C50.6399 80.5774 54.8306 84.6253 60.0001 84.6253C65.1696 84.6253 69.3603 80.5774 69.3603 75.5842C69.3603 70.5909 65.1696 66.543 60.0001 66.543ZM65.574 27.8571V53.863H55.4776V36.2288H46.4329L49.2898 27.8571H65.574Z" fill="white"/>
+          <svg
+            width="120"
+            height="120"
+            viewBox="0 0 120 120"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <circle cx="60" cy="60" r="60" fill="#00B812" />
+            <path
+              fillRule="evenodd"
+              clipRule="evenodd"
+              d="M60 59.026C69.4677 59.026 77.1429 66.4394 77.1429 75.5845C77.1429 84.7294 69.4677 92.1429 60 92.1429C50.5323 92.1429 42.8571 84.7294 42.8571 75.5845C42.8571 66.4394 50.5323 59.026 60 59.026ZM60.0001 66.543C54.8306 66.543 50.6399 70.5909 50.6399 75.5842C50.6399 80.5774 54.8306 84.6253 60.0001 84.6253C65.1696 84.6253 69.3603 80.5774 69.3603 75.5842C69.3603 70.5909 65.1696 66.543 60.0001 66.543ZM65.574 27.8571V53.863H55.4776V36.2288H46.4329L49.2898 27.8571H65.574Z"
+              fill="white"
+            />
           </svg>
           <div className="welcome-page__header">{t('welcome')}</div>
           <div className="welcome-page__description">
@@ -60,6 +83,14 @@ export default class Welcome extends PureComponent {
             onClick={this.handleContinue}
           >
             {t('getStarted')}
+          </Button>
+          <div>or</div>
+          <Button
+            type="secondary"
+            className="first-time-flow__button connect-hw-only__button"
+            onClick={this.handleContinueHwOnly}
+          >
+            {t('hwOnlyStarted')}
           </Button>
         </div>
       </div>

--- a/ui/app/pages/first-time-flow/welcome/welcome.component.js
+++ b/ui/app/pages/first-time-flow/welcome/welcome.component.js
@@ -41,13 +41,13 @@ export default class Welcome extends PureComponent {
     }
   }
 
-  handleContinue = () => {
-    this.props.setHwOnlyModeAsync(false);
+  handleContinue = async () => {
+    await this.props.setHwOnlyModeAsync(false);
     this.props.history.push(INITIALIZE_SELECT_ACTION_ROUTE);
   };
 
-  handleContinueHwOnly = () => {
-    this.props.setHwOnlyModeAsync(true);
+  handleContinueHwOnly = async () => {
+    await this.props.setHwOnlyModeAsync(true);
     this.props.setFirstTimeFlowType(CONST_FIRST_TIME_FLOW_TYPES.CONNECT_HW);
     this.props.history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
   };

--- a/ui/app/pages/first-time-flow/welcome/welcome.component.js
+++ b/ui/app/pages/first-time-flow/welcome/welcome.component.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'events';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import trim from 'lodash/trim';
 import Mascot from '../../../components/ui/mascot';
 import Button from '../../../components/ui/button';
 import {
@@ -51,8 +52,15 @@ export default class Welcome extends PureComponent {
     this.props.history.push(INITIALIZE_METAMETRICS_OPT_IN_ROUTE);
   };
 
+  getOnBoardingStartChoices() {
+    const choiceStr =
+      process.env.ENV_ON_BOARDING_START_CHOICE || 'normal,hardware';
+    return choiceStr.split(',').map(trim);
+  }
+
   render() {
     const { t } = this.context;
+    const choices = this.getOnBoardingStartChoices();
 
     return (
       <div className="welcome-page__wrapper">
@@ -77,21 +85,26 @@ export default class Welcome extends PureComponent {
             <div>{t('metamaskDescription')}</div>
             <div>{t('happyToSeeYou')}</div>
           </div>
-          <Button
-            type="primary"
-            className="first-time-flow__button"
-            onClick={this.handleContinue}
-          >
-            {t('getStarted')}
-          </Button>
-          <div>or</div>
-          <Button
-            type="secondary"
-            className="first-time-flow__button connect-hw-only__button"
-            onClick={this.handleContinueHwOnly}
-          >
-            {t('hwOnlyStarted')}
-          </Button>
+          <div className="welcome-page__buttons">
+            {choices.includes('normal') && (
+              <Button
+                type="primary"
+                className="first-time-flow__button"
+                onClick={this.handleContinue}
+              >
+                {t('getStarted')}
+              </Button>
+            )}
+            {choices.includes('hardware') && (
+              <Button
+                type="secondary"
+                className="first-time-flow__button connect-hw-only__button"
+                onClick={this.handleContinueHwOnly}
+              >
+                {t('hwOnlyStarted')}
+              </Button>
+            )}
+          </div>
         </div>
       </div>
     );

--- a/ui/app/pages/first-time-flow/welcome/welcome.container.js
+++ b/ui/app/pages/first-time-flow/welcome/welcome.container.js
@@ -1,21 +1,29 @@
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import { compose } from 'redux';
-import { closeWelcomeScreen } from '../../../store/actions';
+import {
+  closeWelcomeScreen,
+  setFirstTimeFlowType,
+  setHwOnlyModeAsync,
+} from '../../../store/actions';
+
 import Welcome from './welcome.component';
 
 const mapStateToProps = ({ metamask }) => {
-  const { welcomeScreenSeen, participateInMetaMetrics } = metamask;
+  const { welcomeScreenSeen, participateInMetaMetrics, hwOnlyMode } = metamask;
 
   return {
     welcomeScreenSeen,
     participateInMetaMetrics,
+    hwOnlyMode,
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
     closeWelcomeScreen: () => dispatch(closeWelcomeScreen()),
+    setFirstTimeFlowType: (type) => dispatch(setFirstTimeFlowType(type)),
+    setHwOnlyModeAsync: (status) => dispatch(setHwOnlyModeAsync(status)),
   };
 };
 

--- a/ui/app/pages/first-time-flow/welcome/welcome.container.js
+++ b/ui/app/pages/first-time-flow/welcome/welcome.container.js
@@ -23,7 +23,7 @@ const mapDispatchToProps = (dispatch) => {
   return {
     closeWelcomeScreen: () => dispatch(closeWelcomeScreen()),
     setFirstTimeFlowType: (type) => dispatch(setFirstTimeFlowType(type)),
-    setHwOnlyModeAsync: (status) => dispatch(setHwOnlyModeAsync(status)),
+    setHwOnlyModeAsync: (val) => dispatch(setHwOnlyModeAsync(val)),
   };
 };
 

--- a/ui/app/pages/home/home.component.js
+++ b/ui/app/pages/home/home.component.js
@@ -169,6 +169,7 @@ export default class Home extends PureComponent {
     const {
       history,
       shouldShowSeedPhraseReminder,
+      hwOnlyMode,
       isPopup,
       selectedAddress,
       restoreFromThreeBox,
@@ -209,7 +210,7 @@ export default class Home extends PureComponent {
             key="home-web3ShimUsageNotification"
           />
         ) : null}
-        {shouldShowSeedPhraseReminder ? (
+        {!hwOnlyMode && shouldShowSeedPhraseReminder ? (
           <HomeNotification
             descriptionText={t('backupApprovalNotice')}
             acceptText={t('backupNow')}

--- a/ui/app/pages/home/home.container.js
+++ b/ui/app/pages/home/home.container.js
@@ -3,9 +3,11 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import {
   activeTabHasPermissions,
+  getAccountType,
   getCurrentEthBalance,
   getFirstPermissionRequest,
   getIsMainnet,
+  getMetaMaskAccountsConnected,
   getOriginOfCurrentTab,
   getTotalUnapprovedCount,
   getWeb3ShimUsageStateForOrigin,
@@ -52,8 +54,12 @@ const mapStateToProps = (state) => {
     connectedStatusPopoverHasBeenShown,
     defaultHomeActiveTabName,
     swapsState,
+    hwOnlyMode,
     pendingApprovals = {},
   } = metamask;
+  const connectedAccounts = getMetaMaskAccountsConnected(state);
+  const accountType = getAccountType(state);
+
   const accountBalance = getCurrentEthBalance(state);
   const { forgottenPassword, threeBoxLastUpdated } = appState;
   const totalUnapprovedCount = getTotalUnapprovedCount(state);
@@ -78,6 +84,9 @@ const mapStateToProps = (state) => {
       WEB3_SHIM_USAGE_ALERT_STATES.RECORDED;
 
   return {
+    hwOnlyMode,
+    connectedAccounts,
+    accountType,
     forgottenPassword,
     suggestedTokens,
     swapsEnabled,

--- a/ui/app/pages/home/index.scss
+++ b/ui/app/pages/home/index.scss
@@ -1,4 +1,10 @@
 .home {
+  &__connect-hw {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 30px;
+  }
   &__container {
     display: flex;
     min-height: 100%;

--- a/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
+++ b/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
@@ -9,10 +9,17 @@ import CheckBox, {
   UNCHECKED,
 } from '../../../components/ui/check-box';
 import Tooltip from '../../../components/ui/tooltip';
-import { PRIMARY } from '../../../helpers/constants/common';
+import {
+  CONST_ACCOUNT_TYPES,
+  PRIMARY,
+} from '../../../helpers/constants/common';
 import UserPreferencedCurrencyDisplay from '../../../components/app/user-preferenced-currency-display';
 import PermissionsConnectHeader from '../../../components/app/permissions-connect-header';
 import PermissionsConnectFooter from '../../../components/app/permissions-connect-footer';
+import {
+  getAccountMetaInfo,
+  goToPageConnectHardware,
+} from '../../../helpers/utils/util';
 
 export default class ChooseAccount extends Component {
   static propTypes = {
@@ -31,6 +38,8 @@ export default class ChooseAccount extends Component {
     cancelPermissionsRequest: PropTypes.func.isRequired,
     permissionsRequestId: PropTypes.string.isRequired,
     selectedAccountAddresses: PropTypes.object.isRequired,
+    hwOnlyMode: PropTypes.bool,
+    keyrings: PropTypes.array,
     targetDomainMetadata: PropTypes.shape({
       extensionId: PropTypes.string,
       icon: PropTypes.string,
@@ -88,10 +97,21 @@ export default class ChooseAccount extends Component {
   }
 
   renderAccountsList = () => {
-    const { accounts, nativeCurrency, addressLastConnectedMap } = this.props;
+    const {
+      accounts,
+      nativeCurrency,
+      addressLastConnectedMap,
+      keyrings,
+      hwOnlyMode,
+    } = this.props;
     const { selectedAccounts } = this.state;
     return (
       <div className="permissions-connect-choose-account__accounts-list">
+        {!accounts.length && (
+          <div className="permissions-connect-choose-account__accounts-list__no-accounts">
+            {this.context.t('noAccountsFound')}
+          </div>
+        )}
         {accounts.map((account, index) => {
           const { address, addressLabel, balance } = account;
           return (
@@ -137,7 +157,7 @@ export default class ChooseAccount extends Component {
 
   renderAccountsListHeader() {
     const { t } = this.context;
-    const { selectNewAccountViaModal, accounts } = this.props;
+    const { selectNewAccountViaModal, accounts, hwOnlyMode } = this.props;
     const { selectedAccounts } = this.state;
 
     let checked;
@@ -182,27 +202,81 @@ export default class ChooseAccount extends Component {
             </Tooltip>
           </div>
         ) : null}
-        <div
-          className="permissions-connect-choose-account__text-blue"
-          onClick={() =>
-            selectNewAccountViaModal(this.handleAccountClick.bind(this))
-          }
+        {!hwOnlyMode && (
+          <div
+            className="permissions-connect-choose-account__text-blue"
+            onClick={() =>
+              selectNewAccountViaModal(this.handleAccountClick.bind(this))
+            }
+          >
+            {this.context.t('newAccount')}
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  renderActionsFooter() {
+    const {
+      selectAccounts,
+      permissionsRequestId,
+      cancelPermissionsRequest,
+      accounts,
+      hwOnlyMode,
+    } = this.props;
+    const { selectedAccounts } = this.state;
+    const { t } = this.context;
+    const hasAccounts = accounts && accounts.length > 0;
+
+    let buttons = (
+      <>
+        <Button
+          onClick={() => cancelPermissionsRequest(permissionsRequestId)}
+          type="default"
         >
-          {this.context.t('newAccount')}
+          {t('cancel')}
+        </Button>
+        <Button
+          onClick={() => selectAccounts(selectedAccounts)}
+          type="primary"
+          disabled={selectedAccounts.size === 0 || !hasAccounts}
+        >
+          {t('next')}
+        </Button>
+      </>
+    );
+    if (!hasAccounts && hwOnlyMode) {
+      buttons = (
+        <>
+          <Button
+            onClick={() => cancelPermissionsRequest(permissionsRequestId)}
+            type="default"
+          >
+            {t('cancel')}
+          </Button>
+          <Button
+            type="primary"
+            onClick={() => {
+              goToPageConnectHardware();
+            }}
+          >
+            {t('connectHardwareWallet')}
+          </Button>
+        </>
+      );
+    }
+    return (
+      <div className="permissions-connect-choose-account__footer-container">
+        <PermissionsConnectFooter />
+        <div className="permissions-connect-choose-account__bottom-buttons">
+          {buttons}
         </div>
       </div>
     );
   }
 
   render() {
-    const {
-      selectAccounts,
-      permissionsRequestId,
-      cancelPermissionsRequest,
-      targetDomainMetadata,
-      accounts,
-    } = this.props;
-    const { selectedAccounts } = this.state;
+    const { targetDomainMetadata, accounts } = this.props;
     const { t } = this.context;
     return (
       <div className="permissions-connect-choose-account">
@@ -219,24 +293,7 @@ export default class ChooseAccount extends Component {
         />
         {this.renderAccountsListHeader()}
         {this.renderAccountsList()}
-        <div className="permissions-connect-choose-account__footer-container">
-          <PermissionsConnectFooter />
-          <div className="permissions-connect-choose-account__bottom-buttons">
-            <Button
-              onClick={() => cancelPermissionsRequest(permissionsRequestId)}
-              type="default"
-            >
-              {t('cancel')}
-            </Button>
-            <Button
-              onClick={() => selectAccounts(selectedAccounts)}
-              type="primary"
-              disabled={selectedAccounts.size === 0}
-            >
-              {t('next')}
-            </Button>
-          </div>
-        </div>
+        {this.renderActionsFooter()}
       </div>
     );
   }

--- a/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
+++ b/ui/app/pages/permissions-connect/choose-account/choose-account.component.js
@@ -16,10 +16,7 @@ import {
 import UserPreferencedCurrencyDisplay from '../../../components/app/user-preferenced-currency-display';
 import PermissionsConnectHeader from '../../../components/app/permissions-connect-header';
 import PermissionsConnectFooter from '../../../components/app/permissions-connect-footer';
-import {
-  getAccountMetaInfo,
-  goToPageConnectHardware,
-} from '../../../helpers/utils/util';
+import { goToPageConnectHardware } from '../../../helpers/utils/util';
 
 export default class ChooseAccount extends Component {
   static propTypes = {

--- a/ui/app/pages/permissions-connect/choose-account/index.js
+++ b/ui/app/pages/permissions-connect/choose-account/index.js
@@ -1,1 +1,14 @@
-export { default } from './choose-account.component';
+import { connect } from 'react-redux';
+import { getMetaMaskKeyrings } from '../../../selectors';
+import ChooseAccount from './choose-account.component';
+
+const mapStateToProps = (state) => {
+  const { hwOnlyMode } = state.metamask;
+
+  return {
+    hwOnlyMode,
+    keyrings: getMetaMaskKeyrings(state),
+  };
+};
+
+export default connect(mapStateToProps)(ChooseAccount);

--- a/ui/app/pages/permissions-connect/choose-account/index.scss
+++ b/ui/app/pages/permissions-connect/choose-account/index.scss
@@ -51,6 +51,16 @@
     border-radius: 8px;
     margin-top: 8px;
     overflow-y: auto;
+
+    &__no-accounts {
+
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 16px;
+      height: 100%;
+      box-sizing: border-box;
+    }
   }
 
   &__accounts-list-header--one-item,
@@ -176,7 +186,11 @@
     }
 
     button {
-      width: 124px;
+      flex: 1;
+
+      + button {
+        margin-left: 16px;
+      }
     }
 
     .btn-default {

--- a/ui/app/pages/permissions-connect/permissions-connect.component.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.component.js
@@ -17,7 +17,7 @@ export default class PermissionConnect extends Component {
     getRequestAccountTabIds: PropTypes.func.isRequired,
     getCurrentWindowTab: PropTypes.func.isRequired,
     accounts: PropTypes.array.isRequired,
-    currentAddress: PropTypes.string.isRequired,
+    currentAddress: PropTypes.string,
     origin: PropTypes.string,
     showNewAccountModal: PropTypes.func.isRequired,
     newAccountNumber: PropTypes.number.isRequired,
@@ -52,7 +52,9 @@ export default class PermissionConnect extends Component {
 
   state = {
     redirecting: false,
-    selectedAccountAddresses: new Set([this.props.currentAddress]),
+    selectedAccountAddresses: this.props.currentAddress
+      ? new Set([this.props.currentAddress])
+      : new Set([]),
     permissionsApproved: null,
     origin: this.props.origin,
     targetDomainMetadata: this.props.targetDomainMetadata || {},

--- a/ui/app/pages/permissions-connect/permissions-connect.container.js
+++ b/ui/app/pages/permissions-connect/permissions-connect.container.js
@@ -7,6 +7,7 @@ import {
   getLastConnectedInfo,
   getDomainMetadata,
   getSelectedAddress,
+  getAccountType,
 } from '../../selectors';
 
 import { formatDate } from '../../helpers/utils/util';
@@ -21,6 +22,7 @@ import {
   CONNECT_ROUTE,
   CONNECT_CONFIRM_PERMISSIONS_ROUTE,
 } from '../../helpers/constants/routes';
+import { CONST_ACCOUNT_TYPES } from '../../helpers/constants/common';
 import PermissionApproval from './permissions-connect.component';
 
 const mapStateToProps = (state, ownProps) => {
@@ -30,8 +32,14 @@ const mapStateToProps = (state, ownProps) => {
     },
     location: { pathname },
   } = ownProps;
+  const { hwOnlyMode } = state.metamask;
   const permissionsRequests = getPermissionsRequests(state);
-  const currentAddress = getSelectedAddress(state);
+  let currentAddress = getSelectedAddress(state);
+  const currentAccountType = getAccountType(state);
+
+  if (hwOnlyMode && currentAccountType !== CONST_ACCOUNT_TYPES.HARDWARE) {
+    currentAddress = '';
+  }
 
   const permissionsRequest = permissionsRequests.find(
     (req) => req.metadata.id === permissionsRequestId,

--- a/ui/app/pages/routes/routes.component.js
+++ b/ui/app/pages/routes/routes.component.js
@@ -97,6 +97,11 @@ export default class Routes extends Component {
     metricsEvent: PropTypes.func,
   };
 
+  constructor(props) {
+    super(props);
+    global.onekeyHistory = props.history;
+  }
+
   UNSAFE_componentWillMount() {
     const {
       currentCurrency,

--- a/ui/app/pages/settings/security-tab/security-tab.component.js
+++ b/ui/app/pages/settings/security-tab/security-tab.component.js
@@ -13,6 +13,7 @@ export default class SecurityTab extends PureComponent {
   static propTypes = {
     warning: PropTypes.string,
     history: PropTypes.object,
+    hwOnlyMode: PropTypes.bool,
     participateInMetaMetrics: PropTypes.bool.isRequired,
     setParticipateInMetaMetrics: PropTypes.func.isRequired,
     showIncomingTransactions: PropTypes.bool.isRequired,
@@ -23,7 +24,10 @@ export default class SecurityTab extends PureComponent {
 
   renderSeedWords() {
     const { t } = this.context;
-    const { history } = this.props;
+    const { history, hwOnlyMode } = this.props;
+    if (hwOnlyMode) {
+      return null;
+    }
 
     return (
       <div className="settings-page__content-row">

--- a/ui/app/pages/settings/security-tab/security-tab.container.js
+++ b/ui/app/pages/settings/security-tab/security-tab.container.js
@@ -17,10 +17,12 @@ const mapStateToProps = (state) => {
     featureFlags: { showIncomingTransactions } = {},
     participateInMetaMetrics,
     usePhishDetect,
+    hwOnlyMode
   } = metamask;
 
   return {
     warning,
+    hwOnlyMode,
     showIncomingTransactions,
     participateInMetaMetrics,
     usePhishDetect,

--- a/ui/app/pages/settings/settings-tab/settings-tab.component.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.component.js
@@ -30,7 +30,9 @@ export default class SettingsTab extends PureComponent {
   };
 
   static propTypes = {
+    setHwOnlyModeAsync: PropTypes.func,
     setUseBlockie: PropTypes.func,
+    hwOnlyMode: PropTypes.bool,
     setUseAutoSwitchChain: PropTypes.func,
     setCurrentCurrency: PropTypes.func,
     warning: PropTypes.string,
@@ -149,6 +151,29 @@ export default class SettingsTab extends PureComponent {
     );
   }
 
+  renderHWOnlyOptIn() {
+    const { t } = this.context;
+    const { setHwOnlyModeAsync, hwOnlyMode } = this.props;
+
+    return (
+      <div className="settings-page__content-row">
+        <div className="settings-page__content-item">
+          <span>{this.context.t('hwOnlyModeSwitch')}</span>
+        </div>
+        <div className="settings-page__content-item">
+          <div className="settings-page__content-item-col">
+            <ToggleButton
+              value={hwOnlyMode}
+              onToggle={(value) => setHwOnlyModeAsync(!value)}
+              offLabel={t('off')}
+              onLabel={t('on')}
+            />
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   renderUsePrimaryCurrencyOptions() {
     const { t } = this.context;
     const {
@@ -218,6 +243,7 @@ export default class SettingsTab extends PureComponent {
         {this.renderCurrentLocale()}
         {this.renderBlockieOptIn()}
         {this.renderAutoSwitchChainOptIn()}
+        {this.renderHWOnlyOptIn()}
       </div>
     );
   }

--- a/ui/app/pages/settings/settings-tab/settings-tab.container.js
+++ b/ui/app/pages/settings/settings-tab/settings-tab.container.js
@@ -6,6 +6,7 @@ import {
   updateCurrentLocale,
   setUseNativeCurrencyAsPrimaryCurrencyPreference,
   setParticipateInMetaMetrics,
+  setHwOnlyModeAsync,
 } from '../../../store/actions';
 import { getPreferences } from '../../../selectors';
 import SettingsTab from './settings-tab.component';
@@ -22,6 +23,7 @@ const mapStateToProps = (state) => {
     useBlockie,
     useAutoSwitchChain,
     currentLocale,
+    hwOnlyMode,
   } = metamask;
   const { useNativeCurrencyAsPrimaryCurrency } = getPreferences(state);
 
@@ -32,6 +34,7 @@ const mapStateToProps = (state) => {
     conversionDate,
     nativeCurrency,
     useBlockie,
+    hwOnlyMode,
     useAutoSwitchChain,
     useNativeCurrencyAsPrimaryCurrency,
   };
@@ -48,6 +51,7 @@ const mapDispatchToProps = (dispatch) => {
     },
     setParticipateInMetaMetrics: (val) =>
       dispatch(setParticipateInMetaMetrics(val)),
+    setHwOnlyModeAsync: (val) => dispatch(setHwOnlyModeAsync(val)),
   };
 };
 

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -16,6 +16,7 @@ export default class UnlockPage extends Component {
   static propTypes = {
     history: PropTypes.object.isRequired,
     isUnlocked: PropTypes.bool,
+    hwOnlyMode: PropTypes.bool,
     onImport: PropTypes.func,
     onRestore: PropTypes.func,
     onSubmit: PropTypes.func,
@@ -138,13 +139,16 @@ export default class UnlockPage extends Component {
   render() {
     const { password, error } = this.state;
     const { t } = this.context;
-    const { onImport, onRestore } = this.props;
+    const { onImport, onRestore, hwOnlyMode } = this.props;
 
     return (
       <div className="unlock-page__container">
         <div className="unlock-page">
           <div className="unlock-page__mascot-container">
-            <img src="images/logo.svg" style={{ width: '120px', height: '120px' }} />
+            <img
+              src="images/logo.svg"
+              style={{ width: '120px', height: '120px' }}
+            />
           </div>
           <h1 className="unlock-page__title">{t('welcomeBack')}</h1>
           <div>{t('unlockMessage')}</div>
@@ -163,17 +167,19 @@ export default class UnlockPage extends Component {
             />
           </form>
           {this.renderSubmitButton()}
-          <div className="unlock-page__links">
-            <button className="unlock-page__link" onClick={() => onRestore()}>
-              {t('restoreFromSeed')}
-            </button>
-            <button
-              className="unlock-page__link unlock-page__link--import"
-              onClick={() => onImport()}
-            >
-              {t('importUsingSeed')}
-            </button>
-          </div>
+          {!hwOnlyMode && (
+            <div className="unlock-page__links">
+              <button className="unlock-page__link" onClick={() => onRestore()}>
+                {t('restoreFromSeed')}
+              </button>
+              <button
+                className="unlock-page__link unlock-page__link--import"
+                onClick={() => onImport()}
+              >
+                {t('importUsingSeed')}
+              </button>
+            </div>
+          )}
         </div>
       </div>
     );

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -7,6 +7,7 @@ import TextField from '../../components/ui/text-field';
 import Mascot from '../../components/ui/mascot';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import { isInDebugTestEnv } from '../../helpers/utils/util';
+import { CONST_DEFAULT_PASSWORD_IN_TEST } from '../../helpers/constants/common';
 
 export default class UnlockPage extends Component {
   static contextTypes = {
@@ -26,7 +27,7 @@ export default class UnlockPage extends Component {
   };
 
   state = {
-    password: isInDebugTestEnv() ? '88888888' : '',
+    password: isInDebugTestEnv() ? CONST_DEFAULT_PASSWORD_IN_TEST : '',
     error: null,
   };
 

--- a/ui/app/pages/unlock-page/unlock-page.component.js
+++ b/ui/app/pages/unlock-page/unlock-page.component.js
@@ -6,6 +6,7 @@ import getCaretCoordinates from 'textarea-caret';
 import TextField from '../../components/ui/text-field';
 import Mascot from '../../components/ui/mascot';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import { isInDebugTestEnv } from '../../helpers/utils/util';
 
 export default class UnlockPage extends Component {
   static contextTypes = {
@@ -25,7 +26,7 @@ export default class UnlockPage extends Component {
   };
 
   state = {
-    password: '',
+    password: isInDebugTestEnv() ? '88888888' : '',
     error: null,
   };
 

--- a/ui/app/pages/unlock-page/unlock-page.container.js
+++ b/ui/app/pages/unlock-page/unlock-page.container.js
@@ -18,9 +18,10 @@ import UnlockPage from './unlock-page.component';
 
 const mapStateToProps = (state) => {
   const {
-    metamask: { isUnlocked },
+    metamask: { isUnlocked, hwOnlyMode },
   } = state;
   return {
+    hwOnlyMode,
     isUnlocked,
   };
 };

--- a/ui/app/selectors/first-time-flow.js
+++ b/ui/app/selectors/first-time-flow.js
@@ -9,7 +9,7 @@ export function getFirstTimeFlowTypeRoute(state) {
   const { firstTimeFlowType } = state.metamask;
 
   let nextRoute;
-  // firstTimeFlowType HW only
+  // Page metametrics-opt-in nextRoute for firstTimeFlowType if click [HW only] button
   if (firstTimeFlowType === CONST_FIRST_TIME_FLOW_TYPES.CONNECT_HW) {
     nextRoute = INITIALIZE_CREATE_PASSWORD_ROUTE;
   } else if (firstTimeFlowType === CONST_FIRST_TIME_FLOW_TYPES.CREATE) {

--- a/ui/app/selectors/first-time-flow.js
+++ b/ui/app/selectors/first-time-flow.js
@@ -3,14 +3,18 @@ import {
   INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE,
   DEFAULT_ROUTE,
 } from '../helpers/constants/routes';
+import { CONST_FIRST_TIME_FLOW_TYPES } from '../helpers/constants/common';
 
 export function getFirstTimeFlowTypeRoute(state) {
   const { firstTimeFlowType } = state.metamask;
 
   let nextRoute;
-  if (firstTimeFlowType === 'create') {
+  // firstTimeFlowType HW only
+  if (firstTimeFlowType === CONST_FIRST_TIME_FLOW_TYPES.CONNECT_HW) {
     nextRoute = INITIALIZE_CREATE_PASSWORD_ROUTE;
-  } else if (firstTimeFlowType === 'import') {
+  } else if (firstTimeFlowType === CONST_FIRST_TIME_FLOW_TYPES.CREATE) {
+    nextRoute = INITIALIZE_CREATE_PASSWORD_ROUTE;
+  } else if (firstTimeFlowType === CONST_FIRST_TIME_FLOW_TYPES.IMPORT) {
     nextRoute = INITIALIZE_IMPORT_WITH_SEED_PHRASE_ROUTE;
   } else {
     nextRoute = DEFAULT_ROUTE;

--- a/ui/app/selectors/selectors.js
+++ b/ui/app/selectors/selectors.js
@@ -6,14 +6,18 @@ import {
   TEST_CHAINS,
   NETWORK_TYPE_RPC,
   NETWORK_TYPE_TO_ID_MAP,
-  BUILDINT_PROVIDER_TYPES
+  BUILDINT_PROVIDER_TYPES,
 } from '../../../shared/constants/network';
 import {
   shortenAddress,
   checksumAddress,
   getAccountByAddress,
+  keyringTypeToAccountType,
+  getAccountMetaInfo,
+  getAccountKeyring,
 } from '../helpers/utils/util';
-import { contractMap } from "../../../shared/tokens"
+import { contractMap } from '../../../shared/tokens';
+import { CONST_ACCOUNT_TYPES } from '../helpers/constants/common';
 import { getPermissionsRequestCount } from './permissions';
 
 export function getNetworkIdentifier(state) {
@@ -43,31 +47,18 @@ export function getCurrentKeyring(state) {
     return null;
   }
 
-  const simpleAddress = stripHexPrefix(identity.address).toLowerCase();
-
-  const keyring = state.metamask.keyrings.find((kr) => {
-    return (
-      kr.accounts.includes(simpleAddress) ||
-      kr.accounts.includes(identity.address)
-    );
+  return getAccountKeyring({
+    account: identity,
+    keyrings: state.metamask.keyrings,
   });
-
-  return keyring;
 }
 
+// current selected account type
 export function getAccountType(state) {
   const currentKeyring = getCurrentKeyring(state);
-  const type = currentKeyring && currentKeyring.type;
+  const keyringType = currentKeyring && currentKeyring.type;
 
-  switch (type) {
-    case 'Trezor Hardware':
-    case 'Ledger Hardware':
-      return 'hardware';
-    case 'Simple Key Pair':
-      return 'imported';
-    default:
-      return 'default';
-  }
+  return keyringTypeToAccountType(keyringType);
 }
 
 export function getCurrentNetworkId(state) {
@@ -77,21 +68,34 @@ export function getCurrentNetworkId(state) {
 export const getMetaMaskAccounts = createSelector(
   getMetaMaskAccountsRaw,
   getMetaMaskCachedBalances,
-  (currentAccounts, cachedBalances) =>
+  getMetaMaskKeyrings,
+  (currentAccounts, cachedBalances, keyrings) =>
     Object.entries(currentAccounts).reduce(
       (selectedAccounts, [accountID, account]) => {
+        const accountMeta = getAccountMetaInfo({
+          account: { address: accountID },
+          keyrings,
+        });
+        let accountToAdd = {};
         if (account.balance === null || account.balance === undefined) {
-          return {
-            ...selectedAccounts,
+          accountToAdd = {
             [accountID]: {
+              ...accountMeta,
               ...account,
               balance: cachedBalances && cachedBalances[accountID],
+            },
+          };
+        } else {
+          accountToAdd = {
+            [accountID]: {
+              ...accountMeta,
+              ...account,
             },
           };
         }
         return {
           ...selectedAccounts,
-          [accountID]: account,
+          ...accountToAdd,
         };
       },
       {},
@@ -99,6 +103,7 @@ export const getMetaMaskAccounts = createSelector(
 );
 
 export function getSelectedAddress(state) {
+  // current selected account address
   return state.metamask.selectedAddress;
 }
 
@@ -122,6 +127,10 @@ export function getMetaMaskKeyrings(state) {
   return state.metamask.keyrings;
 }
 
+export function getMetaMaskState(state) {
+  return state.metamask;
+}
+
 export function getMetaMaskIdentities(state) {
   return state.metamask.identities;
 }
@@ -140,14 +149,27 @@ export function getMetaMaskCachedBalances(state) {
  * Get ordered (by keyrings) accounts with identity and balance
  */
 export const getMetaMaskAccountsOrdered = createSelector(
+  getHwOnlyMode,
   getMetaMaskKeyrings,
   getMetaMaskIdentities,
   getMetaMaskAccounts,
-  (keyrings, identities, accounts) =>
-    keyrings
+  (hwOnlyMode, keyrings, identities, accounts) => {
+    const orderedAccounts = keyrings
       .reduce((list, keyring) => list.concat(keyring.accounts), [])
-      .filter((address) => Boolean(identities[address]))
-      .map((address) => ({ ...identities[address], ...accounts[address] })),
+      .filter((address) => {
+        if (hwOnlyMode && accounts[address]?.accountType) {
+          if (accounts[address].accountType !== CONST_ACCOUNT_TYPES.HARDWARE) {
+            return false;
+          }
+        }
+        return Boolean(identities[address]);
+      })
+      .map((address) => {
+        const account = { ...identities[address], ...accounts[address] };
+        return account;
+      });
+    return orderedAccounts;
+  },
 );
 
 export const getMetaMaskAccountsConnected = createSelector(
@@ -157,10 +179,10 @@ export const getMetaMaskAccountsConnected = createSelector(
 );
 
 export function isBalanceCached(state) {
-  const selectedAccount = state.metamask.accounts[getSelectedAddress(state)]
+  const selectedAccount = state.metamask.accounts[getSelectedAddress(state)];
   const selectedAccountBalance = selectedAccount && selectedAccount.balance;
   const cachedBalance = getSelectedAccountCachedBalance(state);
-  
+
   return Boolean(!selectedAccountBalance && cachedBalance);
 }
 
@@ -192,8 +214,8 @@ export function getAssetImages(state) {
 }
 
 export function getContractMap(state) {
-  const type = state.metamask.provider.type;
-  return contractMap[type] ? contractMap[type] : contractMap.eth
+  const { type } = state.metamask.provider;
+  return contractMap[type] ? contractMap[type] : contractMap.eth;
 }
 
 export function getAddressBook(state) {
@@ -266,6 +288,10 @@ export function getCurrentCurrency(state) {
   return state.metamask.currentCurrency;
 }
 
+export function getHwOnlyMode(state) {
+  return state.metamask.hwOnlyMode;
+}
+
 export function getTotalUnapprovedCount(state) {
   const {
     unapprovedMsgCount = 0,
@@ -335,8 +361,11 @@ export function getProvider(state) {
 }
 
 export function getEtherLogo(state) {
-  const type = state.metamask.provider.type;
-  return (NETWORK_TYPE_TO_ID_MAP[type] && NETWORK_TYPE_TO_ID_MAP[type].image) || "./images/eth_logo.svg"
+  const { type } = state.metamask.provider;
+  return (
+    (NETWORK_TYPE_TO_ID_MAP[type] && NETWORK_TYPE_TO_ID_MAP[type].image) ||
+    './images/eth_logo.svg'
+  );
 }
 
 export function getAdvancedInlineGasShown(state) {

--- a/ui/app/store/actionConstants.js
+++ b/ui/app/store/actionConstants.js
@@ -95,6 +95,8 @@ export const UPDATE_PREFERENCES = 'UPDATE_PREFERENCES';
 // Onboarding
 export const COMPLETE_ONBOARDING = 'COMPLETE_ONBOARDING';
 
+export const SET_HW_ONLY_MODE = 'SET_HW_ONLY_MODE';
+
 export const SET_MOUSE_USER_STATE = 'SET_MOUSE_USER_STATE';
 
 // Network

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -2122,12 +2122,12 @@ export function completeOnboarding() {
   };
 }
 
-export function setHwOnlyModeAsync(status = true) {
+export function setHwOnlyModeAsync(value = true) {
   return async (dispatch) => {
-    await promisifiedBackground.setHwOnlyMode(status);
+    await promisifiedBackground.setHwOnlyMode(value);
     dispatch({
       type: actionConstants.SET_HW_ONLY_MODE,
-      value: status,
+      value,
     });
   };
 }

--- a/ui/app/store/actions.js
+++ b/ui/app/store/actions.js
@@ -328,7 +328,6 @@ export function importWatchAccount(address) {
   };
 }
 
-
 export function importNewAccount(strategy, args) {
   return async (dispatch) => {
     let newState;
@@ -2120,6 +2119,16 @@ export function setCompletedOnboarding() {
 export function completeOnboarding() {
   return {
     type: actionConstants.COMPLETE_ONBOARDING,
+  };
+}
+
+export function setHwOnlyModeAsync(status = true) {
+  return async (dispatch) => {
+    await promisifiedBackground.setHwOnlyMode(status);
+    dispatch({
+      type: actionConstants.SET_HW_ONLY_MODE,
+      value: status,
+    });
   };
 }
 


### PR DESCRIPTION
# Fixes

OneKeyHQ/TaskHub#1504

# Explanation

基本实现流程

- welcome界面 `开始使用` 下面增加一个 `仅连接硬件使用` 的按钮
- 点击按钮后，设置redux状态hwOnlyMode为true，并同步写入到插件的localStore持久化存储
- 进入新建主钱包流程，会根据hwOnlyMode判断，跳过主钱包助记词备份步骤
- 主钱包创建成功，进入插件，如果没有连接硬件，隐藏默认的主钱包信息，仅显示一个引导连接硬件的按钮
- 账号选择列表隐藏非硬件钱包的账号
- dapps连接钱包授权弹窗，隐藏非硬件钱包账号，底部增加引导连接硬件按钮

TODO

- [x] 禁止弹出`请备份您的账户助记词，保证您的钱包和资金安全。`提示
- [x] 添加 ENV_ON_BOARDING_START_CHOICE=normal,hardware
- [x] 设置界面增加开关HW Only

# Manual testing steps

-
- 
