### PR TITLE
hwOnly bug fix & perf fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: "pre-release"
 on:
   push:
     tags:
-      - 'v*-*' # push tag like "v1.0.3-beta.1" "v1.0.3-rc.1"
+      - 'v*' # push tag like "v1.0.3-beta.1" "v1.0.3-rc.1" "v1.0.3"
 
 jobs:
   pre-release:

--- a/app/scripts/controllers/transactions/index.js
+++ b/app/scripts/controllers/transactions/index.js
@@ -892,7 +892,10 @@ export default class TransactionController extends EventEmitter {
     updateSubscription();
 
     function updateSubscription() {
-      const pendingTxs = [].concat(txStateManager.getPendingTransactions(), txStateManager.getApprovedTransactions());
+      const pendingTxs = [].concat(
+        txStateManager.getPendingTransactions(),
+        txStateManager.getApprovedTransactions(),
+      );
       if (!listenersAreActive && pendingTxs.length > 0) {
         blockTracker.on('latest', latestBlockHandler);
         listenersAreActive = true;

--- a/app/scripts/lib/account-tracker.js
+++ b/app/scripts/lib/account-tracker.js
@@ -20,7 +20,7 @@ import {
   ROPSTEN_CHAIN_ID,
   KOVAN_CHAIN_ID,
   BSC_CHAIN_ID,
-  HECO_CHAIN_ID
+  HECO_CHAIN_ID,
 } from '../../../shared/constants/network';
 
 import {
@@ -29,10 +29,9 @@ import {
   SINGLE_CALL_BALANCES_ADDRESS_ROPSTEN,
   SINGLE_CALL_BALANCES_ADDRESS_KOVAN,
   SINGLE_CALL_BALANCES_ADDRESS_BSC,
-  SINGLE_CALL_BALANCES_ADDRESS_HECO
+  SINGLE_CALL_BALANCES_ADDRESS_HECO,
 } from '../constants/contracts';
 import { bnToHex } from './util';
-import { Array } from 'globalthis/implementation';
 
 /**
  * This module is responsible for tracking any number of accounts and caching their current balances & transaction
@@ -304,7 +303,11 @@ export default class AccountTracker {
         Promise.all(addresses.map(this._updateAccount.bind(this)));
         return;
       }
-      if (result && Array.isArray(result) && addresses.length === result.length) {
+      if (
+        result &&
+        Array.isArray(result) &&
+        addresses.length === result.length
+      ) {
         addresses.forEach((address, index) => {
           const balance = bnToHex(result[index]);
           accounts[address] = { address, balance };

--- a/app/scripts/migrations/052.js
+++ b/app/scripts/migrations/052.js
@@ -5,7 +5,6 @@ description of migration and what it does
 
 */
 
-import { Object } from 'globalthis/implementation';
 import { cloneDeep, sortedUniqBy, isEqual } from 'lodash';
 
 const version = 52;
@@ -25,10 +24,7 @@ export default {
 
 function transformState(state) {
   if (state.PreferencesController) {
-    const {
-      accountTokens,
-      accountHiddenTokens,
-    } = state.PreferencesController;
+    const { accountTokens, accountHiddenTokens } = state.PreferencesController;
 
     const newAccountTokens = {};
     const newAccountHiddenTokens = {};
@@ -37,39 +33,43 @@ function transformState(state) {
       for (const address of Object.keys(accountTokens)) {
         for (const chainId of Object.keys(accountTokens[address])) {
           if (!newAccountTokens[chainId]) {
-            newAccountTokens[chainId] = []
+            newAccountTokens[chainId] = [];
           }
           newAccountTokens[chainId] = [].concat(
             newAccountTokens[chainId],
-            accountTokens[address][chainId]
+            accountTokens[address][chainId],
           );
         }
       }
-      state.PreferencesController.accountTokens = Object.entries(newAccountTokens)
-      .map(([key, tokens]) => {
-        return { [key]: sortedUniqBy(tokens, isEqual) }
-      })
-      .reduce((result, item) => ({ ...result, ...item }), {});
+      state.PreferencesController.accountTokens = Object.entries(
+        newAccountTokens,
+      )
+        .map(([key, tokens]) => {
+          return { [key]: sortedUniqBy(tokens, isEqual) };
+        })
+        .reduce((result, item) => ({ ...result, ...item }), {});
     }
 
     if (accountHiddenTokens && Object.keys(accountHiddenTokens).length > 0) {
       for (const address of Object.keys(accountHiddenTokens)) {
         for (const chainId of Object.keys(accountHiddenTokens[address])) {
           if (!newAccountHiddenTokens[chainId]) {
-            newAccountHiddenTokens[chainId] = []
+            newAccountHiddenTokens[chainId] = [];
           }
           newAccountHiddenTokens[chainId] = [].concat(
             newAccountHiddenTokens[chainId],
-            accountHiddenTokens[address][chainId]
+            accountHiddenTokens[address][chainId],
           );
         }
       }
-      state.PreferencesController.accountHiddenTokens = Object.entries(newAccountHiddenTokens)
-      .map(([key, tokens]) => {
-        return { [key]: sortedUniqBy(tokens, isEqual) }
-      })
-      .reduce((result, item) => ({ ...result, ...item }), {});
+      state.PreferencesController.accountHiddenTokens = Object.entries(
+        newAccountHiddenTokens,
+      )
+        .map(([key, tokens]) => {
+          return { [key]: sortedUniqBy(tokens, isEqual) };
+        })
+        .reduce((result, item) => ({ ...result, ...item }), {});
     }
-  } 
+  }
   return state;
 }

--- a/development/build/manifest.js
+++ b/development/build/manifest.js
@@ -28,6 +28,15 @@ function createManifestTasks({ browserPlatforms }) {
           ),
         );
         const result = merge(cloneDeep(baseManifest), platformModifications);
+        if (
+          process.env.GITHUB_TAG &&
+          // tag should like: v1.0.3-beta.1
+          /^v[0-9.]+-\w+/giu.test(process.env.GITHUB_TAG || '')
+        ) {
+          // add GITHUB_TAG in description
+          // convenience to identify different version for multiple extension testing
+          result.description = `${result.description} (${process.env.GITHUB_TAG})`;
+        }
         const dir = path.join('.', 'dist', platform);
         await fs.mkdir(dir, { recursive: true });
         await writeJson(result, path.join(dir, 'manifest.json'));
@@ -45,6 +54,7 @@ function createManifestTasks({ browserPlatforms }) {
       ...manifest.background,
       scripts,
     };
+    manifest.description = `${manifest.description} (## DEV_VERSION ##)`;
     manifest.permissions = [...manifest.permissions, 'webRequestBlocking'];
   });
 

--- a/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
+++ b/ui/app/components/app/transaction-activity-log/transaction-activity-log.component.js
@@ -7,6 +7,7 @@ import {
 } from '../../../helpers/utils/conversions.util';
 import { formatDate } from '../../../helpers/utils/util';
 import { getEtherscanNetwork } from '../../../../lib/etherscan-prefix-for-network';
+import { ETH } from '../../../helpers/constants/common';
 import TransactionActivityLogIcon from './transaction-activity-log-icon';
 import { CONFIRMED_STATUS } from './transaction-activity-log.constants';
 
@@ -26,11 +27,14 @@ export default class TransactionActivityLog extends PureComponent {
     onCancel: PropTypes.func,
     onRetry: PropTypes.func,
     primaryTransaction: PropTypes.object,
+    rpcPrefs: PropTypes.object,
     isEarliestNonce: PropTypes.bool,
   };
 
   handleActivityClick = (hash) => {
-    if (!hash) return;
+    if (!hash) {
+      return;
+    }
     const { primaryTransaction, rpcPrefs } = this.props;
     const { metamaskNetworkId } = primaryTransaction;
 
@@ -85,14 +89,15 @@ export default class TransactionActivityLog extends PureComponent {
       index === 0
         ? `${getValueFromWeiHex({
             value,
-            fromCurrency: 'ETH',
-            toCurrency: 'ETH',
+            fromCurrency: ETH,
+            toCurrency: ETH,
             conversionRate,
             numberOfDecimals: 6,
           })} ${nativeCurrency}`
         : getEthConversionFromWeiHex({
             value,
-            fromCurrency: 'ETH',
+            fromCurrency: ETH,
+            nativeCurrency,
             conversionRate,
             numberOfDecimals: 6,
           });

--- a/ui/app/helpers/utils/conversions.util.js
+++ b/ui/app/helpers/utils/conversions.util.js
@@ -28,6 +28,7 @@ export function decimalToHex(decimal) {
 export function getEthConversionFromWeiHex({
   value,
   fromCurrency = ETH,
+  nativeCurrency = ETH,
   conversionRate,
   numberOfDecimals = 6,
 }) {
@@ -46,7 +47,11 @@ export function getEthConversionFromWeiHex({
     });
 
     if (convertedValue !== '0' || i === denominations.length - 1) {
-      nonZeroDenomination = `${convertedValue} ${denominations[i]}`;
+      let unitName = denominations[i];
+      if (unitName === ETH && nativeCurrency) {
+        unitName = nativeCurrency;
+      }
+      nonZeroDenomination = `${convertedValue} ${unitName}`;
       break;
     }
   }

--- a/ui/app/selectors/permissions.js
+++ b/ui/app/selectors/permissions.js
@@ -1,5 +1,4 @@
 import { forOwn } from 'lodash';
-import { Object } from 'globalthis/implementation';
 import { CAVEAT_NAMES } from '../../../shared/constants/permissions';
 import { CONST_ACCOUNT_TYPES } from '../helpers/constants/common';
 import { getMetaMaskAccounts } from './selectors';
@@ -95,8 +94,12 @@ export function getConnectedDomainsForSelectedAddress(state) {
 }
 
 export function getAllAccountsAsArray(state) {
-  const accounts = getMetaMaskAccounts(state);
-  return Object.values(accounts);
+  // getMetaMaskAccounts() will return all accounts
+  //    including ghost account added by /new-account/connect pagination view
+  let accounts = Object.values(getMetaMaskAccounts(state));
+  // so we should remove these ghost account which has NOT keyring
+  accounts = accounts.filter((account) => account && account.accountKeyring);
+  return accounts;
 }
 
 export function getNonHardwareAccounts(state) {


### PR DESCRIPTION
# Fixes

OneKeyHQ/TaskHub#1686
OneKeyHQ/TaskHub#1725
OneKeyHQ/TaskHub#1504

# Explanation

- 测试包和本地开发包在manifest的描述添加GitTag版本信息，方便测试多个插件区分版本
- 修复交易活动日志的gas费单位（BSC下显示为BNB而不是ETH）
- 修复hwOnly切换时白屏问题（导入硬件账户时，会把所有分页读取的账户添加到redux中，即使用户未勾选这些账户，导致后续代码处理这些影子账户导致异常）
- 针对tx.history优化，判断如果是修改error字段的history进行删除，避免history数据过大导致程序卡顿
- 如果tx的创建时间超过3天，并且链上查询一直为null抛异常，则本地标记dropped，以后不会再对这个tx进行链上查询和更新

> tx.history是小狐狸通过`fast-json-patch`库，将tx的数据变更历史记录下来，可能是为了方便开发者对用户的state进行调试分析，同时活动日志的数据也是通过history解析出来的。但是如果程序运行过程中发生了异常，会不停更新 `tx.warning.error` 字段，并将变更记录追加到history数组上（虽然是同一种错误，但是每次链上请求的id不同，导致包含这个id的errorMessage也在变化），导致history数据庞大插件卡顿。优化的方案是，仅过滤掉更新error动作的记录，不影响新增error动作的记录，对于用户老数据，如果数组长度大于100，则删除error更新动作的记录，因为只是过滤了异常信息的变更历史，不影响正常业务的处理（例如活动日志显示）

# Manual testing steps

-
- 
